### PR TITLE
[FEAT] 튜토리얼 페이지 구현

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -46,6 +46,7 @@ const RAW_RUNTIME_STATE =
           ["prettier", "npm:3.2.5"],\
           ["react", "npm:18.2.0"],\
           ["react-dom", "virtual:fd4f55053c8cdae447f294d3a1e99ff87045251a7a8cef733bc5fdf5b798015c077b90691ee2c49baa99520dab6cc204f31b095225f66788a17b176e6f141858#npm:18.2.0"],\
+          ["swiper", "npm:11.0.6"],\
           ["typescript", "patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"]\
         ],\
         "linkType": "SOFT"\
@@ -1572,6 +1573,7 @@ const RAW_RUNTIME_STATE =
           ["prettier", "npm:3.2.5"],\
           ["react", "npm:18.2.0"],\
           ["react-dom", "virtual:fd4f55053c8cdae447f294d3a1e99ff87045251a7a8cef733bc5fdf5b798015c077b90691ee2c49baa99520dab6cc204f31b095225f66788a17b176e6f141858#npm:18.2.0"],\
+          ["swiper", "npm:11.0.6"],\
           ["typescript", "patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"]\
         ],\
         "linkType": "SOFT"\
@@ -4321,6 +4323,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/supports-preserve-symlinks-flag-npm-1.0.0-f17c4d0028-10c0.zip/node_modules/supports-preserve-symlinks-flag/",\
         "packageDependencies": [\
           ["supports-preserve-symlinks-flag", "npm:1.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["swiper", [\
+      ["npm:11.0.6", {\
+        "packageLocation": "../.yarn/berry/cache/swiper-npm-11.0.6-f58772ff1e-10c0.zip/node_modules/swiper/",\
+        "packageDependencies": [\
+          ["swiper", "npm:11.0.6"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@tanstack/react-query-devtools": "^5.20.5",
     "next": "14.1.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "swiper": "^11.0.6"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,94 @@
-export default function Home() {
+import { Pagination } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/css";
+import "swiper/css/pagination";
+import { useRouter } from "next/router";
+
+export default function Tutorial() {
+  const router = useRouter();
+
+  // 튜토리얼 메세지
+  interface TutorialSlide {
+    id: number;
+    title: string;
+    description: string;
+  }
+
+  const tutorialSlides = [
+    {
+      id: 0,
+      title: "도착한 쪽지",
+      description: `매일 오전 9시, 푸바오가 질문이 담긴 쪽지를 보내요!\n
+      쪽지를 클릭해 질문을 확인해보세요\n
+      오후 8시 59분까지 쪽지에 대한 편지를 보낼 수 있답니다`,
+    },
+    {
+      id: 1,
+      title: "푸바오의 답장",
+      description: `편지를 보냈다면 매일 오후 9시, 답장을 받을 수 있어요\n
+      푸바오가 내 이름을 불러주며 보내는 답장을 받아보세요`,
+    },
+    {
+      id: 2,
+      title: "푸바오를 향한 나의 마음",
+      description: `
+      편지 하나를 쓸 때마다 마음의 온도가 조금씩 올라가요\n
+      매일매일 편지를 써 36.5℃를 채워보세요
+      `,
+    },
+    {
+      id: 3,
+      title: "내 앨범 속 푸바오의 답장",
+      description: `
+      받은 답장을 캘린더에 모아볼 수 있어요\n
+      편지지에 담긴 답장을 다운로드 해서 간직할 수도 있답니다!
+      `,
+    },
+  ];
+
   return (
-    <>
-      dearbao
-    </>
+    <Swiper
+      modules={[Pagination]}
+      spaceBetween={50}
+      slidesPerView={1}
+      pagination={{ clickable: true }}
+      style={{
+        width: "100%",
+        display: "flex",
+        justifyContent: "center",
+      }}
+    >
+      {tutorialSlides.map((slide: TutorialSlide) => (
+        <SwiperSlide
+          key={slide.id}
+          style={{
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              width: "100%",
+            }}
+          >
+            <h2>{slide.title}</h2>
+            <p style={{ whiteSpace: "pre-line" }}>{slide.description}</p>
+            {slide.id === 3 ? (
+              <button
+                onClick={() => router.push("/onboarding")}
+                style={{ backgroundColor: "red" }}
+              >
+                시작하기
+              </button>
+            ) : (
+              ""
+            )}
+          </div>
+        </SwiperSlide>
+      ))}
+    </Swiper>
   );
 }

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -1,0 +1,7 @@
+const Onboarding = () => {
+    return (
+        <p>온보딩 페이지</p>
+    );
+};
+
+export default Onboarding;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -168,3 +168,25 @@ body {
   -ms-user-select: none;
   user-select: none;
 }
+
+/* swiper */
+.swiper {
+  width: 100%;
+  height: 100%;
+}
+
+.swiper-slide {
+  text-align: center;
+  font-size: 18px;
+  background: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.swiper-slide img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,6 +1185,7 @@ __metadata:
     prettier: "npm:^3.2.5"
     react: "npm:^18"
     react-dom: "npm:^18"
+    swiper: "npm:^11.0.6"
     typescript: "npm:^5"
   languageName: unknown
   linkType: soft
@@ -3400,6 +3401,13 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
+  languageName: node
+  linkType: hard
+
+"swiper@npm:^11.0.6":
+  version: 11.0.6
+  resolution: "swiper@npm:11.0.6"
+  checksum: 10c0/efdf2a207fb4534aced2db42c14b249eebba76ad497e14d6bd0a07019e2afe2509e02602e2e51167b362f65e27e4ab9c4f86e23764dbeba341745549a6f28ff3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 관련 이슈
close #3 

## 작업 내역
**1. 튜토리얼 페이지 구현**
- 아직 디자인이 나오지 않아서, **기능적으로만 구현해두었습니다.**
- [swiper 라이브러리](https://swiperjs.com/)를 사용하여, 캐러셀 기능을 구현하였습니다.

## 작업 화면

https://github.com/YouAndMyFuBao/dearbao/assets/97885933/9fdf1f79-443f-47eb-b211-c7089068dfec

## 전달 사항
- 첫 방문 유저인지를 판별하여, 아래와 같이 방문 로직을 구현해야 할 것 같습니다. (**미구현**)
  - 첫 방문 유저 O -> 튜토리얼 페이지
  - 첫 방문 유저 X -> 온보딩 페이지
 
- swiper 관련 css를 `global.css 파일`에 추가해두었습니다. 별도로 분리할 지 고민입니다.