### PR TITLE
[FEAT] 모아보기 페이지 구현

### DIFF
--- a/src/pages/collecting/components/calendar.tsx
+++ b/src/pages/collecting/components/calendar.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+
+interface CalendarProps {
+  dataForDates?: Record<string, string>;
+}
+
+const Calendar: React.FC<CalendarProps> = ({ dataForDates }) => {
+    const [showModal, setShowModal] = useState<boolean>(false);
+    const [currentDate, setCurrentDate] = useState<Date>(new Date());
+    const [selectedDateState, setSelectedDateState] = useState<Date | null>();
+
+  // 날짜 선택
+  const handleDateClick = (date: Date) => {
+    if (showModal) {
+      setShowModal(false);
+      console.log("모달창 닫기");
+    }
+    setSelectedDateState(date);
+    setShowModal(true);
+  };
+
+  // 월 선택
+  const handleMonthChange = (increment: number) => {
+    const newDate = new Date(
+      currentDate.getFullYear(),
+      currentDate.getMonth() + increment,
+      1
+    );
+    setCurrentDate(newDate);
+    setSelectedDateState(null);
+    setShowModal(false);
+  };
+
+  // 오늘로 이동
+  const handleGoToToday = () => {
+    setCurrentDate(new Date());
+    setSelectedDateState(null);
+    setShowModal(false);
+  };
+
+  // 날짜에 데이터가 있는지 확인
+  const isDateWithData = (date: Date) => {
+    const dateString = date.toISOString().split("T")[0];
+    return Boolean(dataForDates?.[dateString]);
+  };
+
+  // 날짜 스타일 변경
+  const getDateCellStyle = (date: Date) => {
+    const today = new Date();
+    const isToday = date.toDateString() === today.toDateString();
+    const isSelectedDate = selectedDateState
+      ? date.toDateString() === selectedDateState.toDateString()
+      : false;
+    const isWithData = isDateWithData(date);
+
+    return {
+      backgroundColor: isWithData ? "lightblue" : "",
+      color: isToday ? "green" : isSelectedDate ? "pink" : "black",
+    };
+  };
+
+  // 달력 렌더링
+  const renderCalendar = () => {
+    const today = currentDate;
+    const daysInMonth = new Date(
+      today.getFullYear(),
+      today.getMonth() + 1,
+      0
+    ).getDate();
+    const firstDayOfMonth = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      1
+    ).getDay();
+    const calendar: JSX.Element[] = [];
+
+    let dayCounter = 1;
+
+    calendar.push(
+      <tr key="header">
+        {["일", "월", "화", "수", "목", "금", "토"].map((day, index) => (
+          <th key={index}>{day}</th>
+        ))}
+      </tr>
+    );
+
+    for (let i = 0; i < 6; i++) {
+      const row: JSX.Element[] = [];
+      for (let j = 0; j < 7; j++) {
+        const dayDate = new Date(
+          today.getFullYear(),
+          today.getMonth(),
+          dayCounter
+        );
+        const isCurrentMonth =
+          dayCounter <= daysInMonth && (i > 0 || j >= firstDayOfMonth);
+
+        row.push(
+          <td
+            key={`${i}-${j}`}
+            onClick={() => handleDateClick(dayDate)}
+            style={isCurrentMonth ? getDateCellStyle(dayDate) : {}}
+          >
+            {isCurrentMonth ? dayCounter++ : ""}
+          </td>
+        );
+      }
+      calendar.push(<tr key={i}>{row}</tr>);
+      if (dayCounter > daysInMonth) {
+        break;
+      }
+    }
+
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th colSpan={7}>
+              <button onClick={() => handleMonthChange(-1)}>이전 달</button>
+              <button
+                onClick={() => handleGoToToday()}
+              >{` ${today.toLocaleString("default", { month: "long", year: "numeric" })} `}</button>
+              <button onClick={() => handleMonthChange(1)}>다음 달</button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>{calendar}</tbody>
+      </table>
+    );
+  };
+
+  return (
+    <div>
+      {renderCalendar()}
+      {showModal && (
+        <div style={{ width: "200px", height: "200px", background: "lightYellow", borderRadius: '8px' }}>
+          <button onClick={() => setShowModal(false)}>닫기</button>
+          <p>모달창</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Calendar;

--- a/src/pages/collecting/index.tsx
+++ b/src/pages/collecting/index.tsx
@@ -1,0 +1,19 @@
+import { useRouter } from "next/router";
+import Calendar from "./components/calendar";
+
+const Collecting = () => {
+  const router = useRouter();
+  const collectingPageTitle = "푸바오와 나의 추억을 모아보세요!";
+
+  return (
+    <>
+      <button onClick={() => router.push("/home")}>back</button>
+      <body>
+        <h1>{collectingPageTitle}</h1>
+        <Calendar />
+      </body>
+    </>
+  );
+};
+
+export default Collecting;

--- a/src/pages/components/navigation-modal/navigation-modal.tsx
+++ b/src/pages/components/navigation-modal/navigation-modal.tsx
@@ -29,7 +29,7 @@ export default function NavigationModal({
             <button onClick={() => router.push("/account-setting")}>
               계정 설정
             </button>
-            <button>모아보기</button>
+            <button onClick={() => router.push("/collecting")}>모아보기</button>
             <button onClick={() => router.push("/inquire/make-inquire")}>
               문의하기
             </button>


### PR DESCRIPTION
## 관련 이슈
close #14 

## 작업 내역
**1. 캘린더 컴포넌트 구현**
- 아래의 기능으로 캘린더 컴포넌트를 구현하였습니다.
- 아직 api가 완성되지 않아, 데이터 유무에 따른 스타일 변경은 구현하지 못 하였습니다.

```
- 월(month) 클릭 -> 오늘 날짜로 이동
- 날짜(date) 클릭 -> 모달창 open
- 현재 날짜 -> color : green
- 선택 날짜 -> color : pink
```

## 작업 화면
https://github.com/YouAndMyFuBao/dearbao/assets/97885933/8975b61c-5873-464b-92ac-38147789fa7b

